### PR TITLE
PR - Pomodoro UI Bugfix

### DIFF
--- a/pomodoro_v2/pomo.py
+++ b/pomodoro_v2/pomo.py
@@ -18,9 +18,9 @@ class PomoTimer:
         self.tabs = ttk.Notebook(self.root)
         self.tabs.pack(fill="both", pady=10, expand=True)
 
-        self.tab1 = ttk.Frame(self.tabs, width=600, height=100)
-        self.tab2 = ttk.Frame(self.tabs, width=600, height=100)
-        self.tab3 = ttk.Frame(self.tabs, width=600, height=100)
+        self.tab1 = ttk.Frame(self.tabs, width=400, height=100)
+        self.tab2 = ttk.Frame(self.tabs, width=400, height=100)
+        self.tab3 = ttk.Frame(self.tabs, width=400, height=100)
 
         self.pomo_timer_label = ttk.Label(self.tab1, text="25:00", font=("Calibri", 48))
         self.pomo_timer_label.pack(pady=20)
@@ -39,16 +39,15 @@ class PomoTimer:
 
         self.grid_layout = ttk.Frame(self.root)
         self.grid_layout.pack(pady=10)
+
         self.start_button = ttk.Button(self.grid_layout, text="Start", command=self.start_timer_thread)
         self.start_button.grid(row=0, column=0)
 
-        self.grid_layout = ttk.Frame(self.root)
-        self.grid_layout.pack(pady=10)
+
         self.skip_button = ttk.Button(self.grid_layout, text="Skip", command=self.skip_clock)
         self.skip_button.grid(row=0, column=1)
 
-        self.grid_layout = ttk.Frame(self.root)
-        self.grid_layout.pack(pady=10)
+
         self.reset_button = ttk.Button(self.grid_layout, text="Reset", command=self.reset_clock)
         self.reset_button.grid(row=0, column=2)
 


### PR DESCRIPTION
# What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description of Bug
- Within the code base, there are three buttons for "Start", "Skip" and "Reset". 
- These are set in a defined grid, populated to columns. 
- This should, in practice, put the buttons next to each other horizontally but the UI appears to place the button vertically, to a point that the content is being cut off of the screen, requiring a manual window resize.

## Evidence of issue
![Pomo_UI_Issue_BeforeFix](https://user-images.githubusercontent.com/106940748/197674206-dcfb5756-541d-4fef-8fb1-f53a624c7934.PNG)
- Reset button and Pomodoro Counter are missing from view
- Can bring into view by manually sizing the window, but would like to avoid this being default user expectation.

## Fix
- On review, confirmed that I had accidentally defined the self.grid_layout | ttk.Frame three separate times, when it is only needed once.
- This was creating a new frame for each button, as opposed to one frame where the buttons were being placed in the grid by column/row values
- The additional frames have been removed, and this is bringing the intended result for the UI
- The fix has also allowed for the GUI window size footprint to be decreased by default (from 600 width to 400) - included in the new code base.

![Pomo_UI_Issue_AfterFix](https://user-images.githubusercontent.com/106940748/197674776-208201fe-2324-491c-b94d-8a0afd6f93bc.PNG)